### PR TITLE
Expose metafields from an argo extension config file

### DIFF
--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -189,6 +189,7 @@ export async function dev(...args: string[]) {
                 extension.type === 'checkout'
                   ? extension.config.extensionPoints
                   : ['Checkout::PostPurchase::Render'],
+              metafields: extension.config?.metafields || [],
             },
           ],
         });

--- a/packages/argo-run/src/utilities.ts
+++ b/packages/argo-run/src/utilities.ts
@@ -57,6 +57,7 @@ export function shouldUseReact(): boolean | 'mini' {
 
 export interface CheckoutExtensionConfig {
   readonly extensionPoints: string[];
+  readonly metafields?: {namespace: string; key: string}[];
 }
 
 export interface CheckoutExtension {


### PR DESCRIPTION
### Background

Resolves https://github.com/Shopify/checkout-web/issues/5036

Currently the `appMetafields` API is returning mock values for local development argo extensions. However, we want developers to have a better experience when working with this API and return actual metafield values from Core which is what should be expected when the extension is registered and running on production. 

### Solution

To do this, we need to expose the metafields config when querying for an extension data through the `/query` endpoint. This will allow us to return specific metafields rather than exposing metafields that are not needed by an extension.

### 🎩 instructions

- On this branch, run `yarn && yarn build && yarn link`
- Clone `argo-checkout-template` and run `yarn && yarn generate --type=CHECKOUT_ARGO_EXTENSION --template=react-typescript`
- Update extension.config.yml to include metafields, something like:
   ```
   ---
  extension_points:
    - Checkout::Feature::Render
  metafields:
    - namespace: test-namespace
      key: test-key
   ```
- Run `yarn link @shopify/argo-run` and `yarn server`
- Open `http://localhost:39351/query` and you should see the metafields config there and should look like:

   <img src="https://user-images.githubusercontent.com/16614405/118682280-4c871800-b7ce-11eb-828e-9983967bee7c.png" width="400px"/>

### Checklist

- [x] I have :tophat:'d these changes
