### PR TITLE
Change log level to show port conflict error

### DIFF
--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -220,7 +220,7 @@ export async function dev(...args: string[]) {
     // we do not want). This was the only approach I found that works —
     // pass `logLevel`, which is not actually typed as being available, but
     // is used when creating the logger :/
-    ...({logLevel: 'silent'} as any),
+    ...({logLevel: 'error'} as any),
     clientLogLevel: 'silent',
     stats: process.env.DEBUG === undefined ? false : 'verbose',
   });


### PR DESCRIPTION
### Background

This PR change log level to show error message including port conflict. Note that, this PR doesn't not terminate the server, it just allow error message goes through. I think it's sufficient enough and generic. 

Resolves https://github.com/Shopify/checkout-web/issues/5067

### Solution

Change log level

### 🎩

- Create new checkout extension `shopify create extension`
- Run the extension via `shopify serve`, note the port
- In this PR run, `yarn && yarn build && cp -R ./packages/* ../your-extension-prodject/node_modules/@shopify/`
- Run the extension in different terminal using same port `yarn start --port <some-port-number>`
- Verify that the error message about port conflict appear

```
yarn start --port 8910
yarn run v1.22.4
$ argo-run dev --port 8910
🔭 > Starting dev server on http://localhost:8910
✖ ｢wds｣:  Error: listen EADDRINUSE: address already in use 0.0.0.0:8910
    at Server.setupListenHandle [as _listen2] (net.js:1316:16)
    at listenInCluster (net.js:1364:12)
    at doListen (net.js:1501:7)
    at processTicksAndRejections (internal/process/task_queues.js:81:21) {
  code: 'EADDRINUSE',
  errno: -48,
  syscall: 'listen',
  address: '0.0.0.0',
  port: 8910
}
```

### Checklist

- [ ] I have :tophat:'d these changes
