### PR TITLE
New flag: publicUrl

### DIFF
--- a/packages/argo-run/src/utilities.ts
+++ b/packages/argo-run/src/utilities.ts
@@ -10,11 +10,11 @@ import {safeLoad as loadYaml} from 'js-yaml';
 // Could bring in a CLI arg library, but this is fun practice :)
 export function namedArgument(
   name: string,
-  args: string[],
+  args: readonly string[],
 ): string | undefined {
   const flag = `--${name}`;
 
-  const reversedInterestingIndex = args
+  const reversedInterestingIndex = [...args]
     .reverse()
     .findIndex((value) => value.startsWith(flag));
 

--- a/scripts/consumer-helper.sh
+++ b/scripts/consumer-helper.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-AVAILABLE_PACKAGES=('argo-admin' 'argo-admin-react' 'argo-checkout', 'argo-checkout-react', 'argo-post-purchase', 'argo-post-purchase-react')
+AVAILABLE_PACKAGES=('argo-admin' 'argo-admin-react' 'argo-checkout', 'argo-checkout-react', 'argo-post-purchase', 'argo-post-purchase-react', 'argo-run')
 ROOT=$(pwd)
 
 # Font color


### PR DESCRIPTION
### Background

Enable argo-run to receive a  `--publicUrl` from the `shopify-app-cli`.  Presence of the flag signals that a tunnel has already been started and that the only step left to do for the developer is to create a checkout.

### Solution

* Enable argo-run to take a new `namedArgument` called `publicUrl`.
* Adjust log output based on the presence of `publicUrl` when telling the developer what to do next.

### 🎩 

#### Checkout extensions

* shopify create extension (Post Purchase)
* _In argo project,_ `yarn build-consumer ../../local/cli-specification-experiment/tunnel-and-serve-cpp-test argo-run`
* _In extension project,_ update extension.config.yml:
  ```
  ---
  extensionPoints: []
  ```
* _In extension project,_ `yarn start --publicUrl http://1234.ngrok.io/`
* Expect output
  ```
  🔭 > Starting dev server on port 39351
  🔭 > Your extension is available at https://1234.ngrok.io/assets/extension.js
  🔭 > Next, you’ll need to create a checkout on your development shop and
  🔭 > append this query string to the first page of checkout: `?dev=https://1234.ngrok.io/query`
   ```

#### Post Purchase Extensions

* shopify create extension (Post Purchase)
* _In argo project,_ `yarn build-consumer ../../local/cli-specification-experiment/tunnel-and-serve-cpp-test argo-run`
* _In extension project,_ `yarn start --publicUrl http://1234.ngrok.io/`
* Expect output
  ```
  yarn run v1.22.10
  $ argo-run serve --port 39351 --publicUrl=https://1234.ngrok.io/
  🔭 > Starting dev server on port 39351
  🔭 > Your extension is available at https://1234.ngrok.io/assets/extension.js
  🔭 > You can append this query string: 
  script_url=https%3A%2F%2F1234.ngrok.io%2Fassets%2Fextension.js&api_key=bf2c252a5e58a8cb5453f363da2c6869
   ```
* _In extension project,_ `yarn start`
* Expect output
  ```
  yarn run v1.22.10
  $ argo-run serve --port 39351
  🔭 > Starting dev server on port 39351
  🔭 > Your extension is available at http://localhost:39351/assets/extension.js
  🔭 > You can append this query string: script_url=http%3A%2F%2Flocalhost%3A39351%2Fassets%2Fextension.js&api_key=bf2c252a5e58a8cb5453f363da2c6869
   ```

### Checklist

- [x] I have :tophat:'d these changes
