### PR TITLE
Doc images and table spacing

### DIFF
--- a/scripts/generate-docs-checkout.ts
+++ b/scripts/generate-docs-checkout.ts
@@ -8,6 +8,7 @@ const paths = {
   },
   outputRoot: '../shopify-dev/content/beta/checkout-extensions',
   shopifyDevUrl: '/beta/checkout-extensions',
+  shopifyDevAssets: '../shopify-dev/app/assets/images/api/checkout-extensions',
 };
 
 const componentsPageContent = {

--- a/scripts/typedoc/shopify-dev-renderer/components.ts
+++ b/scripts/typedoc/shopify-dev-renderer/components.ts
@@ -66,6 +66,8 @@ export async function components(paths: Paths, content: Content) {
     });
     markdown += docsContent ? `${docsContent}\n\n` : '';
 
+    markdown += renderExampleImageFor(name, paths.shopifyDevAssets);
+
     const examples = renderComponentExamplesFor(name, paths.packages);
     if (examples.length > 0) {
       markdown += examples;
@@ -180,6 +182,16 @@ function renderComponentExamplesFor(name: string, packages: Packages): string {
   }
 
   return markdown;
+}
+
+function renderExampleImageFor(componentName: string, shopifyDevAssetsUrl: string) {
+  const filename = componentName.toLowerCase();
+  const image = resolve(`${shopifyDevAssetsUrl}/components/${filename}.png`);
+  if (fs.existsSync(image)) {
+    return `<img src="/assets/api/checkout-extensions/components/${filename}.png" width="50%" alt="${filename}" align="center" />`;
+  }
+
+  return '';
 }
 
 function getAdditionalContentFor(contentFolder: string) {

--- a/scripts/typedoc/shopify-dev-renderer/components.ts
+++ b/scripts/typedoc/shopify-dev-renderer/components.ts
@@ -97,7 +97,7 @@ export async function components(paths: Paths, content: Content) {
     const contentFolder = resolve(
       `${paths.inputRoot}/src/components/${name}/content`,
     );
-    markdown += getAdditionalContentFor(contentFolder);
+    markdown += '\n\n' + getAdditionalContentFor(contentFolder);
 
     fs.writeFile(outputFile, markdown, function (err) {
       if (err) throw err;
@@ -188,7 +188,7 @@ function renderExampleImageFor(componentName: string, shopifyDevAssetsUrl: strin
   const filename = componentName.toLowerCase();
   const image = resolve(`${shopifyDevAssetsUrl}/components/${filename}.png`);
   if (fs.existsSync(image)) {
-    return `<img src="/assets/api/checkout-extensions/components/${filename}.png" width="50%" alt="${filename}" align="center" />`;
+    return `![${filename}](/assets/api/checkout-extensions/components/${filename}.png)`;
   }
 
   return '';

--- a/scripts/typedoc/types.ts
+++ b/scripts/typedoc/types.ts
@@ -7,6 +7,7 @@ export interface Paths {
   outputRoot: string;
   packages: Packages;
   shopifyDevUrl: string;
+  shopifyDevAssets?: string;
 }
 
 export interface Tag {


### PR DESCRIPTION
We are including static images for component examples until we have a live sandbox. This will include the markdown image if it exists.

Also, needed newlines between the props table and additional content.