### PR TITLE
readme generation, subcomponent docs, and build docs from argo

### DIFF
--- a/scripts/generate-docs-checkout.ts
+++ b/scripts/generate-docs-checkout.ts
@@ -1,10 +1,10 @@
 import {extensionPoints, components, gettingStarted} from './typedoc/shopify-dev-renderer';
 
 const paths = {
-  inputRoot: '../checkout-web/packages/argo-checkout',
+  inputRoot: './packages/argo-checkout',
   packages: {
-    JS: '../checkout-web/packages/argo-checkout',
-    React: '../checkout-web/packages/argo-checkout-react',
+    JS: './packages/argo-checkout',
+    React: './packages/argo-checkout-react',
   },
   outputRoot: '../shopify-dev/content/beta/checkout-extensions',
   shopifyDevUrl: '/beta/checkout-extensions',
@@ -26,5 +26,9 @@ const componentsPageContent = {
 }
 
 extensionPoints(paths);
-components(paths, componentsPageContent);
+components(paths, componentsPageContent, {
+  subcomponentMap: {ChoiceList: ['Choice'], FormLayout: ['FormLayoutGroup']},
+  componentsToSkip: ['FormLayoutGroup', 'ListItem', 'Choice'],
+  generateReadmes: true
+});
 gettingStarted(paths);

--- a/scripts/typedoc/shopify-dev-renderer/components.ts
+++ b/scripts/typedoc/shopify-dev-renderer/components.ts
@@ -53,7 +53,7 @@ export async function components(paths: Paths, content: Content, options?: Optio
   index += '<ul style="column-count: auto;column-width: 12rem;">';
 
   components.forEach(({value: {name, docs, props}}: any) => {
-    if (options.componentsToSkip.includes(name)) return;
+    if (options?.componentsToSkip?.includes(name)) return;
 
     const filename = name.toLowerCase();
     const outputFile = `${componentDocsPath}/${filename}.md`;
@@ -106,7 +106,7 @@ export async function components(paths: Paths, content: Content, options?: Optio
     const additionalPropsTablesMd = dedupe(additionalPropsTables).reverse().join('');
     markdown += additionalPropsTablesMd;
 
-    if (Object.keys(options.subcomponentMap).includes(name)) {
+    if (options && options.subcomponentMap && Object.keys(options.subcomponentMap).includes(name)) {
       const subcomponentsMd = options.subcomponentMap[name].map((subcomponent) => {
         const {value: {name: subName, docs: subDocs, props: subProps}} = components.find(({value}: any) => value.name === subcomponent) as any;
 
@@ -150,7 +150,7 @@ export async function components(paths: Paths, content: Content, options?: Optio
       if (err) throw err;
     });
 
-    if (options.generateReadmes === true) {
+    if (options?.generateReadmes === true) {
       const readmeFile = resolve(`${paths.inputRoot}/src/components/${name}/README.md`);
       const title = `# ${name}\n\n`;
       let readmeMarkdown = title + docsContentMd + propsTableMd + additionalPropsTablesMd;

--- a/scripts/typedoc/shopify-dev-renderer/components.ts
+++ b/scripts/typedoc/shopify-dev-renderer/components.ts
@@ -244,7 +244,7 @@ function renderExampleImageFor(componentName: string, shopifyDevAssetsUrl: strin
   const filename = componentName.toLowerCase();
   const image = resolve(`${shopifyDevAssetsUrl}/components/${filename}.png`);
   if (fs.existsSync(image)) {
-    return `![${filename}](/assets/api/checkout-extensions/components/${filename}.png)`;
+    return `---\n### Example\n![${filename}](/assets/api/checkout-extensions/components/${filename}.png)`;
   }
 
   return '';


### PR DESCRIPTION
Generally, the script can now:

- Generate component READMEs for the input package (see #108)
- Skip components
- Map subcomponent content to parent component content

For checkout specifically:

- Making use of the above features
- Now generating the docs from this repo
- Replacing checkout component GitHub links with the shopify.dev link

Closes #112