### PR TITLE
Remove unused GeographicalCoordinates type

### DIFF
--- a/packages/argo-checkout/src/extension-points/api/standard/index.ts
+++ b/packages/argo-checkout/src/extension-points/api/standard/index.ts
@@ -403,11 +403,6 @@ export interface Address {
   phone?: string;
 }
 
-export interface GeographicalCoordinates {
-  latitude: number;
-  longitude: number;
-}
-
 export interface LineItem {
   /**
    * These line item IDs are not stable at the moment, they might change after


### PR DESCRIPTION
Removes an unused type in our Argo API related to geographical coordinates, which we took off the address type.