### PR TITLE
Typo fix for button description

### DIFF
--- a/packages/argo-checkout/src/components/Button/Button.ts
+++ b/packages/argo-checkout/src/components/Button/Button.ts
@@ -28,6 +28,6 @@ export interface ButtonProps {
 }
 
 /**
- * Buttons are used for actions, such as “Add”, “Continue”, or “Pay now”, or “Save”.
+ * Buttons are used for actions, such as “Add”, “Continue”, “Pay now”, or “Save”.
  */
 export const Button = createRemoteComponent<'Button', ButtonProps>('Button');


### PR DESCRIPTION
### Background

Button description has one to many or's.

> Buttons are used for actions, such as “Add”, “Continue”, or “Pay now”, or “Save”.

### Solution
Buttons are used for actions, such as “Add”, “Continue”, “Pay now”, or “Save”.
