### PR TITLE
[post-purchase] Adds redirectUrl to the ApplyChangesetResult type

### DIFF
--- a/packages/argo-post-purchase/src/extension-points/api/post-purchase/post-purchase.ts
+++ b/packages/argo-post-purchase/src/extension-points/api/post-purchase/post-purchase.ts
@@ -217,6 +217,7 @@ type CalculateChangesetResult =
 interface ApplyChangesetResult {
   errors: ChangesetError[];
   status: ChangesetProcessingStatus;
+  redirectUrl?: string;
 }
 
 export type ChangesetProcessingStatus =


### PR DESCRIPTION
### Background

This PR adds a `redirectUrl` attribute to the `ApplyChangesetResult` type for post-purchase.

This new attribute is representing what is already being done at present with the `ApplyChangeset` action. In order to communicate to the frontend where to redirect the user for 3DS authentication in Checkout Post Purchase, we send a `redirectUrl` attribute alongside `errors` and `status`.

### Solution

**Solution section deleted due to this PR being closed.**

### 🎩

There does not seem to be any tophatting that can be applied here, besides a clean CI pipeline.

### Checklist

- [x] I have :tophat:'d these changes 
