### PR TITLE
Fix webSocket for liveReload in Safari

### DIFF
--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -29,9 +29,8 @@ export async function dev(...args: string[]) {
   const publicUrl = namedArgument('publicUrl', args);
   const tunnelStarted = Boolean(publicUrl);
   const filename = 'extension.js';
-  const script = new URL(`${PUBLIC_PATH}${filename}`, publicUrl || url);
-  const scriptUrl = script.toString();
-  const isHttps = script.protocol === 'https:';
+  const scriptUrl = new URL(`${PUBLIC_PATH}${filename}`, publicUrl || url);
+  const isHttps = scriptUrl.protocol === 'https:';
 
   const compiler = webpack(
     createWebpackConfiguration({
@@ -43,8 +42,8 @@ export async function dev(...args: string[]) {
       hotOptions: {
         https: isHttps,
         webSocket: {
-          host: script.hostname,
-          port: Number(script.port) || (isHttps ? 443 : 80),
+          host: scriptUrl.hostname,
+          port: Number(scriptUrl.port) || (isHttps ? 443 : 80),
           path: WEBSOCKET_PATH,
         },
       },
@@ -208,7 +207,7 @@ export async function dev(...args: string[]) {
       // https://github.com/Shopify/post-purchase-devtools/blob/master/src/background/background.ts#L16-L35
       app.get(LEGACY_POST_PURCHASE_DATA_PATH, (_, res) => {
         res.set('Access-Control-Allow-Origin', '*');
-        res.json(getLegacyPostPurchaseData(scriptUrl, extension));
+        res.json(getLegacyPostPurchaseData(scriptUrl.toString(), extension));
       });
     },
 
@@ -254,7 +253,7 @@ export async function dev(...args: string[]) {
   if (isPostPurchaseExtension) {
     log(
       `You can append this query string: ${convertLegacyPostPurchaseDataToQueryString(
-        getLegacyPostPurchaseData(scriptUrl, extension),
+        getLegacyPostPurchaseData(scriptUrl.toString(), extension),
       )}`,
     );
   } else if (tunnelStarted) {

--- a/packages/argo-run/src/dev.ts
+++ b/packages/argo-run/src/dev.ts
@@ -29,10 +29,9 @@ export async function dev(...args: string[]) {
   const publicUrl = namedArgument('publicUrl', args);
   const tunnelStarted = Boolean(publicUrl);
   const filename = 'extension.js';
-  const scriptUrl = new URL(
-    `${PUBLIC_PATH}${filename}`,
-    publicUrl || url,
-  ).toString();
+  const script = new URL(`${PUBLIC_PATH}${filename}`, publicUrl || url);
+  const scriptUrl = script.toString();
+  const isHttps = script.protocol === 'https:';
 
   const compiler = webpack(
     createWebpackConfiguration({
@@ -42,8 +41,12 @@ export async function dev(...args: string[]) {
         publicPath: PUBLIC_PATH,
       },
       hotOptions: {
-        https: false,
-        webSocket: {host: 'localhost', port, path: WEBSOCKET_PATH},
+        https: isHttps,
+        webSocket: {
+          host: script.hostname,
+          port: Number(script.port) || (isHttps ? 443 : 80),
+          path: WEBSOCKET_PATH,
+        },
       },
     }),
   );


### PR DESCRIPTION
### Background

This PR fixes webSocket for liveReload in Safari. Currently, argo-run hardcode localhost for webSocket. It works in Chrome but Safari doesn't like it due to insecure connection. 

Resolves https://github.com/Shopify/checkout-web/issues/5179

### Solution

Shopify cli already pass `publicUrl` argument. It's used to construct the scriptUrl. We can use it to construct webSocket url too. 

### 🎩

- Download latest shopify-app-cli
- Create new checkout extension with shopify cli
- Run `shopify serve`
- Open ngrok url, ex: https://fd1df9e54b46.ngrok.io/query. Verify that socket url looks like `"socketUrl":"wss://fd1df9e54b46.ngrok.io/build"`
- Run `yarn start`
- Open localhost url, ex http://localhost:8910/query. Verify that socket url looks like `"socketUrl":"ws://localhost:8910/build"`
- Add a product and checkout the cart. You can use this shop for testing https://shop1.shopify.remove-line-item.henry-tao.us.spin.dev/
- Verify that the extension is reloaded as normal in both Chrome and Safari.

### Checklist

- [x] I have :tophat:'d these changes
