### PR TITLE
argo-admin-react: fix component props exports

### DIFF
--- a/packages/argo-admin-react/src/components/Badge/index.ts
+++ b/packages/argo-admin-react/src/components/Badge/index.ts
@@ -1,1 +1,2 @@
 export {Badge} from './Badge';
+export type {BadgeProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Banner/index.ts
+++ b/packages/argo-admin-react/src/components/Banner/index.ts
@@ -1,1 +1,2 @@
 export {Banner} from './Banner';
+export type {BannerProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Button/index.ts
+++ b/packages/argo-admin-react/src/components/Button/index.ts
@@ -1,1 +1,2 @@
 export {Button} from './Button';
+export type {ButtonProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Card/index.ts
+++ b/packages/argo-admin-react/src/components/Card/index.ts
@@ -1,1 +1,2 @@
 export {Card} from './Card';
+export type {CardProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/CardSection/index.ts
+++ b/packages/argo-admin-react/src/components/CardSection/index.ts
@@ -1,1 +1,2 @@
 export {CardSection} from './CardSection';
+export type {CardSectionProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Checkbox/index.ts
+++ b/packages/argo-admin-react/src/components/Checkbox/index.ts
@@ -1,1 +1,2 @@
 export {Checkbox} from './Checkbox';
+export type {CheckboxProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Icon/Icon.ts
+++ b/packages/argo-admin-react/src/components/Icon/Icon.ts
@@ -1,6 +1,4 @@
-import {Icon as BaseIcon, IconProps} from '@shopify/argo-admin';
+import {Icon as BaseIcon} from '@shopify/argo-admin';
 import {createRemoteReactComponent} from '@remote-ui/react';
 
 export const Icon = createRemoteReactComponent(BaseIcon);
-
-export {IconProps};

--- a/packages/argo-admin-react/src/components/Icon/index.ts
+++ b/packages/argo-admin-react/src/components/Icon/index.ts
@@ -1,1 +1,2 @@
 export {Icon} from './Icon';
+export type {IconProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Link/index.ts
+++ b/packages/argo-admin-react/src/components/Link/index.ts
@@ -1,1 +1,2 @@
 export {Link} from './Link';
+export type {LinkProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Modal/index.ts
+++ b/packages/argo-admin-react/src/components/Modal/index.ts
@@ -1,1 +1,2 @@
 export {Modal} from './Modal';
+export type {ModalProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/OptionList/index.ts
+++ b/packages/argo-admin-react/src/components/OptionList/index.ts
@@ -1,1 +1,2 @@
 export {OptionList} from './OptionList';
+export type {OptionListProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Pressable/index.ts
+++ b/packages/argo-admin-react/src/components/Pressable/index.ts
@@ -1,1 +1,2 @@
 export {Pressable} from './Pressable';
+export type {PressableProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Radio/index.ts
+++ b/packages/argo-admin-react/src/components/Radio/index.ts
@@ -1,1 +1,2 @@
 export {Radio} from './Radio';
+export type {RadioProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/ResourceItem/index.ts
+++ b/packages/argo-admin-react/src/components/ResourceItem/index.ts
@@ -1,1 +1,2 @@
 export {ResourceItem} from './ResourceItem';
+export type {ResourceItemProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/ResourceList/index.ts
+++ b/packages/argo-admin-react/src/components/ResourceList/index.ts
@@ -1,1 +1,2 @@
 export {ResourceList} from './ResourceList';
+export type {ResourceListProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Select/Select.ts
+++ b/packages/argo-admin-react/src/components/Select/Select.ts
@@ -1,6 +1,4 @@
-import {Select as BaseSelect, SelectProps} from '@shopify/argo-admin';
+import {Select as BaseSelect} from '@shopify/argo-admin';
 import {createRemoteReactComponent} from '@remote-ui/react';
 
 export const Select = createRemoteReactComponent(BaseSelect);
-
-export {SelectProps};

--- a/packages/argo-admin-react/src/components/Select/index.ts
+++ b/packages/argo-admin-react/src/components/Select/index.ts
@@ -1,1 +1,2 @@
 export {Select} from './Select';
+export type {SelectProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Spinner/index.ts
+++ b/packages/argo-admin-react/src/components/Spinner/index.ts
@@ -1,1 +1,2 @@
 export {Spinner} from './Spinner';
+export type {SpinnerProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Stack/index.ts
+++ b/packages/argo-admin-react/src/components/Stack/index.ts
@@ -1,1 +1,2 @@
 export {Stack} from './Stack';
+export type {StackProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/StackItem/index.ts
+++ b/packages/argo-admin-react/src/components/StackItem/index.ts
@@ -1,1 +1,2 @@
 export {StackItem} from './StackItem';
+export type {StackItemProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Text/index.ts
+++ b/packages/argo-admin-react/src/components/Text/index.ts
@@ -1,1 +1,2 @@
 export {Text} from './Text';
+export type {TextProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/TextField/index.ts
+++ b/packages/argo-admin-react/src/components/TextField/index.ts
@@ -1,1 +1,2 @@
 export {TextField} from './TextField';
+export type {TextFieldProps} from '@shopify/argo-admin';

--- a/packages/argo-admin-react/src/components/Thumbnail/index.ts
+++ b/packages/argo-admin-react/src/components/Thumbnail/index.ts
@@ -1,1 +1,2 @@
 export {Thumbnail} from './Thumbnail';
+export type {ThumbnailProps} from '@shopify/argo-admin';


### PR DESCRIPTION
### Background

Related to esnext issue https://github.com/Shopify/argo-private/issues/1524#issuecomment-852318742

### Solution

TS is very strict when it comes to exporting from another package. argo-admin-react re-exports component props from argo-admin so we need to explicitly set these as a type export

### 🎩

1. Run `yarn build` and verify that both argo-admin-react and argo-admin compiles

### Checklist

- [x] I have :tophat:'d these changes
