### PR TITLE
Use 'export type' in argo-admin

### DIFF
--- a/packages/argo-admin-react/src/index.ts
+++ b/packages/argo-admin-react/src/index.ts
@@ -2,5 +2,7 @@ export * from '@shopify/argo-admin/extension-points';
 export * from '@shopify/argo-admin/extension-api';
 
 export * from './api';
+export type {ShopifyApi, RenderCallback} from './api';
+
 export * from './components';
 export * from './extension-api';

--- a/packages/argo-admin/src/extension-points/index.ts
+++ b/packages/argo-admin/src/extension-points/index.ts
@@ -9,14 +9,13 @@ import {
   ProductSubscriptionExtensionPointCallback,
 } from './identifiers/product_subscription';
 
-export {PlaygroundExtensionPoint};
-export {ProductSubscriptionExtensionPoint};
+export type {PlaygroundExtensionPoint, ProductSubscriptionExtensionPoint};
 
 /*
 Placeholder for new imports
 */
 
-export {
+export type {
   ContainerAction,
   ExtensionResult,
   RenderableExtensionCallback,

--- a/packages/argo-admin/src/index.ts
+++ b/packages/argo-admin/src/index.ts
@@ -1,4 +1,53 @@
-export * from './api';
+export {extend} from './api';
+export type {ShopifyApi, ShopifyGlobal} from './api';
+
 export * from './components';
+export type {
+  BadgeProps,
+  BannerProps,
+  ButtonProps,
+  CardProps,
+  CardSectionProps,
+  CheckboxProps,
+  PressableProps,
+  IconProps,
+  ModalProps,
+  LinkProps,
+  RadioProps,
+  ResourceItemProps,
+  ResourceListProps,
+  SelectProps,
+  SpinnerProps,
+  StackProps,
+  StackItemProps,
+  TextProps,
+  TextFieldProps,
+  ThumbnailProps,
+  OptionListProps,
+  DestructableAction,
+  DisableableAction,
+} from './components';
+
 export * from './extension-api';
-export * from './extension-points';
+export type {
+  LayoutApi,
+  Layout,
+  LocaleApi,
+  ContainerApi,
+  ExtensionContainer,
+  DataApi,
+  ExtensionData,
+  SessionTokenApi,
+  ToastApi,
+} from './extension-api';
+
+export type {
+  PlaygroundExtensionPoint,
+  ProductSubscriptionExtensionPoint,
+  ContainerAction,
+  ExtensionResult,
+  RenderableExtensionCallback,
+  ExtensionPoint,
+  ExtensionApi,
+  ExtensionPointCallback,
+} from './extension-points';


### PR DESCRIPTION
### Background

In the `main` branch, run `yarn clean; yarn clear-cache; yarn build`. In `packages/argo-admin/build/esm`, you’ll see import statements referencing empty files. This prevents argo-admin from being used with skypack: <https://cdn.skypack.dev/@shopify/argo-admin>.

### Solution

Always use `export type` when exporting types, so the bundler knows to strip them out.

### 🎩

Run `yarn clean; yarn clear-cache; yarn build` on this branch and you should see no references to types in `build/esm`. ie `build/esm/index.mjs` shouldn't reference `extension-points` at all, as only types are exported from there.

### Checklist

- [x] I have :tophat:'d these changes
