### PR TITLE
Add shared `@shopify/ui-extensions` package

### DIFF
--- a/packages/argo-admin/src/components/Banner/Banner.ts
+++ b/packages/argo-admin/src/components/Banner/Banner.ts
@@ -1,6 +1,5 @@
 import {createRemoteComponent} from '@remote-ui/core';
-
-export type BannerStatus = 'success' | 'info' | 'warning' | 'critical';
+import type {BaseBannerProps} from '@shopify/ui-extensions';
 
 export interface BannerAction {
   /** Callback when the Banner action button is pressed. */
@@ -10,18 +9,9 @@ export interface BannerAction {
   content: string;
 }
 
-export interface BannerProps {
+export interface BannerProps extends BaseBannerProps {
   /** Button to display at bottom of banner. */
   action?: BannerAction;
-
-  /** Colour of the banner. */
-  status?: BannerStatus;
-
-  /** Title of the banner. */
-  title?: string;
-
-  /** Callback when banner is dismissed. */
-  onDismiss: () => void;
 }
 
 /**

--- a/packages/argo-admin/tsconfig.json
+++ b/packages/argo-admin/tsconfig.json
@@ -1,10 +1,14 @@
 {
   "extends": "../../config/typescript/tsconfig.admin.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "rootDir": "../",
     "outDir": "build/ts",
-    "baseUrl": "src"
+    "baseUrl": "./",
+    "paths": {
+      "@shopify/ui-extensions": ["../ui-extensions/src"],
+      "@shopify/ui-extensions/*": ["../ui-extensions/src/*"]
+    }
   },
-  "include": ["./src/**/*.ts"],
+  "include": ["./src/**/*.ts", "../ui-extensions/**/*.ts"],
   "exclude": ["./src/**/*.example.*"]
 }

--- a/packages/ui-extensions/README.md
+++ b/packages/ui-extensions/README.md
@@ -1,0 +1,3 @@
+# `@shopify/ui-extensions`
+
+This package contains shared types and utilities for all of the other ui-extensions packages in this repo.

--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@shopify/ui-extensions",
+  "version": "0.0.1",
+  "main": "index.js",
+  "module": "index.mjs",
+  "esnext": "index.esnext",
+  "types": "index.d.ts",
+  "exports": {
+    ".": {
+      "esnext": "./index.esnext",
+      "import": "./index.mjs",
+      "require": "./index.js"
+    },
+    "./": "./"
+  },
+  "license": "MIT",
+  "sideEffects": false
+}

--- a/packages/ui-extensions/src/index.ts
+++ b/packages/ui-extensions/src/index.ts
@@ -1,0 +1,1 @@
+export * from './types';

--- a/packages/ui-extensions/src/types/Banner.ts
+++ b/packages/ui-extensions/src/types/Banner.ts
@@ -1,0 +1,12 @@
+export type Status = 'critical' | 'info' | 'success' | 'warning';
+
+export interface BaseBannerProps {
+  /** Callback fired when banner is dismissed. */
+  onDismiss?: () => void;
+
+  /** Visual treatment of the banner based on message purpose. */
+  status?: Status;
+
+  /** Title of the banner. */
+  title?: string;
+}

--- a/packages/ui-extensions/src/types/index.ts
+++ b/packages/ui-extensions/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './Banner';

--- a/packages/ui-extensions/tsconfig.json
+++ b/packages/ui-extensions/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../config/typescript/tsconfig.admin.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "build/ts",
+    "jsx": "react-jsx"
+  },
+  "include": ["./src/**/*.ts", "./src/**/*.tsx"]
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     {"path": "./packages/argo-webpack-hot-client"},
     {"path": "./packages/argo-run"},
     {"path": "./packages/argo-admin"},
-    {"path": "./packages/argo-admin-react"}
+    {"path": "./packages/argo-admin-react"},
+    {"path": "./packages/ui-extensions"}
   ]
 }


### PR DESCRIPTION
### Background

Closes: https://github.com/Shopify/argo-private/issues/1488 and https://github.com/Shopify/argo-private/issues/1489
Related to: https://github.com/Shopify/argo-private/issues/1446
Related to: https://github.com/Shopify/argo-rfcs/issues/1

Moving ahead with a set of shared base APIs, this PR adds a shared "package": `@shopify/ui-extensions`. To validate that the build works, the PR also adds `BaseBannerProps`, and extends this API in `argo-admin`. There are no changes in the `Banner` build.

### Solution

This creates a place to add additional shared base APIs. 

### 🎩

- Check out this branch and run `yarn build`
- Open `packages/argo-admin/build/ts/components/Banner/Banner.d.ts`
- Confirm that it contains the exact same props as the current `Banner` API

```ts
    action?: BannerAction;
    status?: BannerStatus;
    title?: string;
    onDismiss: () => void;
```

### Checklist

- [x] I have :tophat:'d these changes
