### PR TITLE
add BaseButtonProps

### DIFF
--- a/packages/ui-extensions/src/types/Button.ts
+++ b/packages/ui-extensions/src/types/Button.ts
@@ -9,7 +9,7 @@ export interface BaseButtonProps {
    * `primary`: button used for main actions or green-path. Ex: Continue to next step, Discount field
    * `secondary`: button used for secondary actions not blocking user progress. Ex: Download Shop app
    * `plain`: Renders a button that visually looks like a Link
-   * @default 'primary'*/
+   */
   kind?: 'primary' | 'secondary' | 'plain';
   /**
    *  Specifies the color of the Button. The button will keep the style of the chosen `kind`,
@@ -28,7 +28,7 @@ export interface BaseButtonProps {
   /**
    * Whether the button should fill all available inline space.
    * */
-  fill?: boolean;
+  inlineSize?: 'fill';
   /**
    * Replaces content with a loading indicator
    */

--- a/packages/ui-extensions/src/types/Button.ts
+++ b/packages/ui-extensions/src/types/Button.ts
@@ -1,0 +1,58 @@
+export interface BaseButtonProps {
+  /**
+   * Destination to link to, renders a Link
+   */
+  to?: string;
+  /**
+   * The type of button that will be rendered.
+   *
+   * `primary`: button used for main actions or green-path. Ex: Continue to next step, Discount field
+   * `secondary`: button used for secondary actions not blocking user progress. Ex: Download Shop app
+   * `plain`: Renders a button that visually looks like a Link
+   * @default 'primary'*/
+  kind?: 'primary' | 'secondary' | 'plain';
+  /**
+   *  Specifies the color of the Button. The button will keep the style of the chodsen `kind`,
+   *  but replace its color according to the appearance.
+   *
+   * `monochrome`: button will inherit the color of its parent
+   * `critical`: button will take inherit the color of the Critical color group (in Checkout)
+   *  		 and map to 'destructive' (in Admin/Polaris). Typically used for destructive actions.
+   *
+   *  Excludes 'success' | 'warning' since buttons in a Banner will be `monochrome`
+   *  and use the default colors set by the Banner.
+   */
+  appearance?: 'monochrome' | 'critical';
+  /** Changes the size of the button
+   * @default 'base'
+   */
+  size?: 'base' | 'large';
+  /**
+   * Whether the button should fill all available inline space.
+   * */
+  fill?: boolean;
+  /**
+   * Replaces content with a loading indicator
+   */
+  loading?: boolean;
+  /**
+   * A label replacing the loading indicator when user prefers reduced motion
+   */
+  loadingLabel?: string;
+  /**
+   * A label that will be announced to buyers using assistive technologies
+   */
+  accessibilityLabel?: string;
+  /**
+   * Disables the button, disallowing any interaction
+   */
+  disabled?: boolean;
+  /**
+   * Allows the button to submit a form
+   */
+  submit?: boolean;
+  /**
+   * Callback when pressed
+   */
+  onPress?(): void;
+}

--- a/packages/ui-extensions/src/types/Button.ts
+++ b/packages/ui-extensions/src/types/Button.ts
@@ -12,15 +12,13 @@ export interface BaseButtonProps {
    * @default 'primary'*/
   kind?: 'primary' | 'secondary' | 'plain';
   /**
-   *  Specifies the color of the Button. The button will keep the style of the chodsen `kind`,
+   *  Specifies the color of the Button. The button will keep the style of the chosen `kind`,
    *  but replace its color according to the appearance.
    *
    * `monochrome`: button will inherit the color of its parent
    * `critical`: button will take inherit the color of the Critical color group (in Checkout)
    *  		 and map to 'destructive' (in Admin/Polaris). Typically used for destructive actions.
    *
-   *  Excludes 'success' | 'warning' since buttons in a Banner will be `monochrome`
-   *  and use the default colors set by the Banner.
    */
   appearance?: 'monochrome' | 'critical';
   /** Changes the size of the button
@@ -36,10 +34,6 @@ export interface BaseButtonProps {
    */
   loading?: boolean;
   /**
-   * A label replacing the loading indicator when user prefers reduced motion
-   */
-  loadingLabel?: string;
-  /**
    * A label that will be announced to buyers using assistive technologies
    */
   accessibilityLabel?: string;
@@ -47,10 +41,6 @@ export interface BaseButtonProps {
    * Disables the button, disallowing any interaction
    */
   disabled?: boolean;
-  /**
-   * Allows the button to submit a form
-   */
-  submit?: boolean;
   /**
    * Callback when pressed
    */

--- a/packages/ui-extensions/src/types/index.ts
+++ b/packages/ui-extensions/src/types/index.ts
@@ -1,1 +1,2 @@
 export * from './Banner';
+export * from './Button';


### PR DESCRIPTION
### Background

Closes: https://github.com/Shopify/argo-private/issues/1487
Relates to: https://github.com/Shopify/argo-rfcs/issues/2

### Solution

This adds the `BaseButtonProps` decided on in this RFC discussion. These props are not yet consumed by either ui-extensions library. 

### 🎩

- This API is not yet consumed and has no impact on the ui-extensions libraries.
