### PR TITLE
Render markdown lists in docs builder

### DIFF
--- a/scripts/typedoc/shopify-dev-renderer/shared.ts
+++ b/scripts/typedoc/shopify-dev-renderer/shared.ts
@@ -305,13 +305,23 @@ export function strip(content: string) {
   );
 }
 
+/**
+ * extract first sentence (line or up to '.') for yaml description field
+ */
 export function firstSentence(content: string) {
   const lines = content.split(/(\n|\. )/g);
   let firstSentence = lines.length ? lines[0] : content;
+
+  // try to split on period if first line doesn't have one
+  if (lines.length && lines[0].indexOf('.') !== 0) {
+    const sentences = content.split('.');
+    firstSentence = sentences[0];
+  }
+
   if (firstSentence[firstSentence.length - 1] !== '.') {
     firstSentence += '.';
   }
-  return firstSentence;
+  return firstSentence.replace('\n', ' ');
 }
 
 function paramsType(

--- a/scripts/typedoc/utilities/dependency-graph.ts
+++ b/scripts/typedoc/utilities/dependency-graph.ts
@@ -328,13 +328,15 @@ function resolveNodeToLocal(
 
       // If this interface extends another, find the base
       // we're extending and grab its properties
-      if(node.extends) {
+      if (node.extends) {
         for (const extens of node.extends) {
-          const resolved = resolveNodeToLocal(extens, context)
-          if(resolved.kind === 'Extends'){
+          const resolved = resolveNodeToLocal(extens, context);
+          if (resolved.kind === 'Extends') {
             const extendedNode = context.resolvedLocals.get(resolved.extends);
-            if(extendedNode && extendedNode.kind === 'InterfaceType') {
-              extendedNode.properties.forEach(property => properties.push(property));
+            if (extendedNode && extendedNode.kind === 'InterfaceType') {
+              extendedNode.properties.forEach((property) =>
+                properties.push(property),
+              );
             }
           }
         }
@@ -536,7 +538,7 @@ function resolveNodeToLocal(
 
     case 'TSExpressionWithTypeArguments': {
       const {expression} = node;
-      if(expression.type === 'Identifier'){
+      if (expression.type === 'Identifier') {
         const name = expression.name;
         return {
           kind: 'Extends',
@@ -669,15 +671,7 @@ function docsFromCommentBlocks(
   const parserContext = parser.parseString(docs.join('\n'));
   const {docComment} = parserContext;
 
-  if (parseTags) {
-    const {content, tags} = contentWithTags(docComment);
-    return {content, tags};
-  } else {
-    // oh microsoft
-    const stringBuilder = new StringBuilder();
-    new TSDocEmitter().renderComment(stringBuilder, docComment);
-    return {content: stringBuilder.toString()};
-  }
+  return contentWithTags(docComment);
 }
 
 function collectLocalsFromStatement(


### PR DESCRIPTION
### Background

Currently we strip newlines from jsdoc comments in a way that makes it impossible to render markdown lists, ie

```
/** Represents an error occurred while calculating or applying a changeset.
 *
 * **Possible values for `code`:** 
 *
 * - `payment_required` - The original payment method couldn't be charged.
 * - `insufficient_inventory` - An item requested to be added is out of stock.
 * - `changeset_already_applied` - Indicates if the changeset has been applied. Changesets can only be applied once.
 * - `unsupported_payment_method` - Indicates that the payment method was unsupported. The payment method used to pay for the initial purchase can't be used to pay for changesets.
 * - `invalid_request` - The request is invalid. It shouldn't be re-sent without modifications.
 * - `server_error` - An unexpected error has happened.
 */
```

### Solution

Stop using the microsoft string builder.

Unfortunately, `contentWithTags` doesn't pick up all tags yet, but I don't think that affects checkout - https://github.com/Shopify/argo/issues/139

### 🎩

- ...

### Checklist

- [x] I have :tophat:'d these changes
