### PR TITLE
Add BaseHeadingProps to shared types

### DIFF
--- a/packages/ui-extensions/src/types/Heading.ts
+++ b/packages/ui-extensions/src/types/Heading.ts
@@ -1,0 +1,20 @@
+type Level = 1 | 2 | 3;
+
+export interface BaseHeadingProps {
+  /**
+   * Unique identifier. Typically used to make the heading a target
+   * that another component can refer to in order to provide an alternative
+   * accessibility label.
+   */
+  id?: string;
+  /**
+   * The visual level of the heading.
+   */
+  level?: Level;
+  /**
+   * A custom accessibility role for this heading. Currently, only `presentation`
+   * is supported. `presentation` will strip the semantic meaning of the heading,
+   * but leave the visual styling intact.
+   */
+  role?: 'presentation';
+}

--- a/packages/ui-extensions/src/types/Heading.ts
+++ b/packages/ui-extensions/src/types/Heading.ts
@@ -1,4 +1,4 @@
-type Level = 1 | 2 | 3;
+export type Level = 1 | 2 | 3;
 
 export interface BaseHeadingProps {
   /**
@@ -12,9 +12,8 @@ export interface BaseHeadingProps {
    */
   level?: Level;
   /**
-   * A custom accessibility role for this heading. Currently, only `presentation`
-   * is supported. `presentation` will strip the semantic meaning of the heading,
-   * but leave the visual styling intact.
+   * A custom accessibility role for this heading.
+   * `presentation` will strip the semantic meaning of the heading, but leave the visual styling intact.
    */
   role?: 'presentation';
 }

--- a/packages/ui-extensions/src/types/index.ts
+++ b/packages/ui-extensions/src/types/index.ts
@@ -1,2 +1,3 @@
 export * from './Banner';
 export * from './Button';
+export * from './Heading';


### PR DESCRIPTION
Closes: Shopify/argo-private#1498
Relates to: Shopify/argo-rfcs#9

### Solution
This adds the `BaseHeadingProps` to the shared `ui-extensions` package. These props are not yet consumed by either ui-extensions library.

This is a pretty straightforward addition to the shared APIs, considering that it is a new component for Admin and matches Checkout's current implementation. 

I do have one question for the Admin team that I overlooked during the RFC discussion.

What should the default heading level be?

In Checkout, the heading will use its “automatic” heading level, which is determined by the level of nesting within ancestor `HeadingGroup`. At this point, we have not discussed creating a `HeadingGroup` in Admin. Is it reasonable to make the default level `1`? (I know this is an implementation detail, but I want to make sure that this API works for the way we work in Admin).

### 🎩

- This API is not yet consumed and has no impact on the ui-extensions libraries.