### PR TITLE
remove the brand 'App Bridge' from .ts files

### DIFF
--- a/packages/argo-post-purchase/src/components/TextField/TextField.ts
+++ b/packages/argo-post-purchase/src/components/TextField/TextField.ts
@@ -103,11 +103,11 @@ export interface TextFieldProps {
    * that point, you are expected to store this “committed value” in state, and reflect
    * it in the text field’s `value` property.
    *
-   * This state management model is important given how App Bridge Checkout renders UI. App Bridge Checkout components
-   * run on a separate thread from the UI, so they can’t respond to input synchronously.
+   * This state management model is important given how remote UI components are rendered.
+   * Components run on a separate thread from the UI, so they can’t respond to input synchronously.
    * A pattern popularized by [controlled React components](https://reactjs.org/docs/forms.html#controlled-components)
    * is to have the component be the source of truth for the input `value`, and update
-   * the `value` on every user input. The delay in responding to events from an App Bridge Checkout
+   * the `value` on every user input. The delay in responding to events from a checkout
    * extension is only a few milliseconds, but attempting to strictly store state with
    * this delay can cause issues if a user types quickly, or if the buyer is using a
    * lower-powered device. Having the UI thread take ownership for “in progress” input,

--- a/packages/argo-post-purchase/src/extension-points/render-extension.ts
+++ b/packages/argo-post-purchase/src/extension-points/render-extension.ts
@@ -15,7 +15,7 @@ interface RenderResult<Input> {
  * the UI as its first argument, and additional data and methods as a second
  * argument. The object that can manipulate the UI is referred to as a `RemoteRoot`,
  * and is provided by the [remote-ui library](https://github.com/Shopify/remote-ui/tree/main/packages/core)
- * on which App Bridge Checkout’s rendering capabilities are built.
+ * on which rendering capabilities are built.
  */
 export interface RenderExtension<
   Input,

--- a/packages/argo-post-purchase/src/extension-points/types.ts
+++ b/packages/argo-post-purchase/src/extension-points/types.ts
@@ -61,7 +61,7 @@ export type InputForRenderExtension<
 > = ExtractedInputFromRenderExtension<RenderExtensions[ID]>;
 
 /**
- * For a given rendering extension point, returns the App Bridge Checkout components that the
+ * For a given rendering extension point, returns the components that the
  * extension point supports.
  */
 export type AllowedComponentsForRenderExtension<


### PR DESCRIPTION
### Background

The brand _App Bridge_ is publicly facing, but the library code should stay unbranded.

### Solution

Removing all mentions of _App Bridge_ from the code (these were added in #136 )
