### PR TITLE
Update @shopify/ui-extensions publish settings to be public

### DIFF
--- a/packages/ui-extensions/package.json
+++ b/packages/ui-extensions/package.json
@@ -14,5 +14,9 @@
     "./": "./"
   },
   "license": "MIT",
-  "sideEffects": false
+  "sideEffects": false,
+  "publishConfig": {
+    "access": "public",
+    "@shopify:registry": "https://registry.npmjs.org/"
+  }
 }


### PR DESCRIPTION
### Background

Admin client package need to reference `@shopify/ui-extensions` and it has to be public so our partners can access it

### Solution

Update publish settings to be public

### 🎩

- ...

### Checklist

- [ ] I have :tophat:'d these changes
